### PR TITLE
feat!: Add runtime font loading from the file system

### DIFF
--- a/sources/engine/Stride.Graphics/Font/FontManager.cs
+++ b/sources/engine/Stride.Graphics/Font/FontManager.cs
@@ -14,7 +14,7 @@ using Stride.Core.Serialization.Contents;
 namespace Stride.Graphics.Font
 {
     /// <summary>
-    /// A font manager is in charge of loading in memory the ttf files, looking for font informations, rendering and then caching the <see cref="CharacterBitmap"/>s on the CPU .
+    /// A font manager is in charge of loading in memory the ttf files, looking for font informations, rendering and then caching the <see cref="CharacterBitmap"/>s on the CPU . 
     /// </summary>
     internal class FontManager : IDisposable
     {
@@ -91,7 +91,7 @@ namespace Stride.Graphics.Font
         }
 
         /// <summary>
-        /// Start the generation of the specified character's bitmap.
+        /// Start the generation of the specified character's bitmap. 
         /// </summary>
         /// <remarks>Does nothing if the bitmap already exist or if the generation is currently running.</remarks>
         /// <param name="characterSpecification">The character we want the bitmap of</param>
@@ -163,7 +163,7 @@ namespace Stride.Graphics.Font
             if (character.Size.X < 1 || character.Size.Y < 1)
                 return;
 
-            // get the face of the font
+            // get the face of the font 
             var fontFace = GetOrCreateFontFace(character.FontName, character.Style);
             lock (freetypeLibrary)
             {
@@ -263,7 +263,7 @@ namespace Stride.Graphics.Font
             // see if the index of the character is valid
             return glyphIndex != 0;
         }
-
+        
         public void Dispose()
         {
             // terminate the build thread
@@ -292,7 +292,7 @@ namespace Stride.Graphics.Font
                 freetypeLibrary.Dispose();
             freetypeLibrary = null;
         }
-
+        
         private Face GetOrCreateFontFace(string fontFamily, FontStyle fontStyle)
         {
             var fontPath = FontHelper.GetFontPath(fontFamily, fontStyle);
@@ -306,7 +306,7 @@ namespace Stride.Graphics.Font
         private void LoadFontInMemory(string fontPath)
         {
             // return if the font is already cached
-            if (cachedFontFaces.ContainsKey(fontPath))
+            if (cachedFontFaces.ContainsKey(fontPath)) 
                 return;
 
             // load the font from the data base
@@ -338,7 +338,7 @@ namespace Stride.Graphics.Font
                     if (character.Size.X < 1 || character.Size.Y < 1)
                         goto DequeueRequest;
 
-                    // get the face of the font
+                    // get the face of the font 
                     var fontFace = GetOrCreateFontFace(character.FontName, character.Style);
 
                     lock (freetypeLibrary)
@@ -360,13 +360,13 @@ namespace Stride.Graphics.Font
                         RenderBitmap(character, fontFace);
                     }
 
-DequeueRequest:
+                DequeueRequest:
 
-// update the generated cached data
+                    // update the generated cached data
                     lock (dataStructuresLock)
                         bitmapsToGenerate.Dequeue();
                 }
             }
-        }
+        }   
     }
 }

--- a/sources/engine/Stride.Graphics/Font/FontManager.cs
+++ b/sources/engine/Stride.Graphics/Font/FontManager.cs
@@ -119,8 +119,14 @@ namespace Stride.Graphics.Font
         /// Loads a font from the specified file on the file system and adds it to the internal font cache for use with
         /// the given font name and style.
         /// </summary>
-        /// <remarks>If a font with the same name and style is already cached, the method does nothing.
-        /// This method is thread-safe when adding new fonts to the cache.</remarks>
+        /// <remarks>
+        /// <para>If a font with the same name and style is already cached, the method does nothing.</para>
+        /// <para>This method is thread-safe when adding new fonts to the cache.</para>
+        /// <para><strong>Memory considerations:</strong> The complete font file data is loaded into memory and kept
+        /// resident for the lifetime of the <see cref="FontManager"/>. Fonts cannot be individually unloaded;
+        /// they are only released when the <see cref="FontManager"/> is disposed. Consider this when loading
+        /// large fonts or many font variants, especially on memory-constrained platforms.</para>
+        /// </remarks>
         /// <param name="fontName">The name to associate with the loaded font. This name is used to reference the font in subsequent
         /// operations.</param>
         /// <param name="filePath">The path to the font file on the file system. The file must exist and be accessible.</param>
@@ -128,21 +134,22 @@ namespace Stride.Graphics.Font
         /// <exception cref="FileNotFoundException">Thrown if the file specified by <paramref name="filePath"/> does not exist.</exception>
         public void LoadFontFromFileSystem(string fontName, string filePath, FontStyle style)
         {
-            if (!File.Exists(filePath))
-                throw new FileNotFoundException($"Font file not found: {filePath}");
-
             var cacheKey = FontHelper.GetFontPath(fontName, style);
 
-            // Return if the font is already cached
+            // Fast path: Return if the font is already cached (avoids lock contention)
             if (cachedFontFaces.ContainsKey(cacheKey))
                 return;
 
-            // Load font data into memory
-            var fontData = File.ReadAllBytes(filePath);
-
-            // Create FreeType face and add to cache
             lock (freetypeLibrary)
             {
+                // Check again inside lock to prevent race condition
+                if (cachedFontFaces.ContainsKey(cacheKey))
+                    return;
+
+                // Load font data into memory
+                var fontData = File.ReadAllBytes(filePath);
+
+                // Create FreeType face and add to cache
                 cachedFontFaces[cacheKey] = freetypeLibrary.NewMemoryFace(fontData, 0);
             }
         }

--- a/sources/engine/Stride.Graphics/Font/FontSystem.cs
+++ b/sources/engine/Stride.Graphics/Font/FontSystem.cs
@@ -22,6 +22,11 @@ namespace Stride.Graphics.Font
         internal readonly HashSet<SpriteFont> AllocatedSpriteFonts = new HashSet<SpriteFont>();
 
         /// <summary>
+        /// Gets the runtime font provider for registering fonts from the file system.
+        /// </summary>
+        internal RuntimeFontProvider RuntimeFonts { get; private set; }
+
+        /// <summary>
         /// Create a new instance of <see cref="FontSystem" /> base on the provided <see cref="Stride.Graphics.GraphicsDevice" />.
         /// </summary>
         public FontSystem()
@@ -40,6 +45,23 @@ namespace Stride.Graphics.Font
             GraphicsDevice = graphicsDevice;
             FontManager = new FontManager(fileProviderService);
             FontCacheManager = new FontCacheManager(this);
+            RuntimeFonts = new RuntimeFontProvider(this);
+        }
+
+        /// <summary>
+        /// Loads a runtime-registered font by name.
+        /// This bypasses the content pipeline entirely.
+        /// </summary>
+        /// <param name="fontName">The registered font name</param>
+        /// <param name="defaultSize">The default font size</param>
+        /// <param name="style">The font style</param>
+        /// <returns>A SpriteFont instance, or null if not registered</returns>
+        public SpriteFont? LoadRuntimeFont(string fontName, float defaultSize = 16f, FontStyle style = FontStyle.Regular)
+        {
+            if (!RuntimeFonts.IsRegistered(fontName, style))
+                return null;
+
+            return NewDynamic(defaultSize, fontName, style);
         }
 
         public void Draw()

--- a/sources/engine/Stride.Graphics/Font/FontSystem.cs
+++ b/sources/engine/Stride.Graphics/Font/FontSystem.cs
@@ -25,8 +25,9 @@ namespace Stride.Graphics.Font
         /// Gets the runtime font provider for registering and managing fonts loaded from the file system.
         /// </summary>
         /// <remarks>
-        /// Use this to register custom fonts at runtime that are not part of the content pipeline.
-        /// Fonts registered through this provider can be loaded using <see cref="LoadRuntimeFont"/>.
+        /// <para>Use this to register custom fonts at runtime that are not part of the content pipeline
+        /// via <see cref="RuntimeFontProvider.RegisterFont"/>.</para>
+        /// <para>Once registered, fonts can be loaded using the <see cref="LoadRuntimeFont"/> method.</para>
         /// </remarks>
         public RuntimeFontProvider RuntimeFonts { get; private set; }
 
@@ -57,9 +58,9 @@ namespace Stride.Graphics.Font
         /// This bypasses the content pipeline entirely.
         /// </summary>
         /// <param name="fontName">The registered font name. If the font is not registered, the method returns <c>null</c>.</param>
-        /// <param name="defaultSize">The default font size</param>
-        /// <param name="style">The font style</param>
-        /// <returns>A SpriteFont instance, or null if not registered</returns>
+        /// <param name="defaultSize">The default font size in pixels.</param>
+        /// <param name="style">The font style.</param>
+        /// <returns>A <see cref="SpriteFont"/> instance if the font is registered; otherwise, <c>null</c>.</returns>
         public SpriteFont? LoadRuntimeFont(string fontName, float defaultSize = 16f, FontStyle style = FontStyle.Regular)
         {
             if (!RuntimeFonts.IsRegistered(fontName, style))

--- a/sources/engine/Stride.Graphics/Font/FontSystem.cs
+++ b/sources/engine/Stride.Graphics/Font/FontSystem.cs
@@ -22,9 +22,13 @@ namespace Stride.Graphics.Font
         internal readonly HashSet<SpriteFont> AllocatedSpriteFonts = new HashSet<SpriteFont>();
 
         /// <summary>
-        /// Gets the runtime font provider for registering fonts from the file system.
+        /// Gets the runtime font provider for registering and managing fonts loaded from the file system.
         /// </summary>
-        internal RuntimeFontProvider RuntimeFonts { get; private set; }
+        /// <remarks>
+        /// Use this to register custom fonts at runtime that are not part of the content pipeline.
+        /// Fonts registered through this provider can be loaded using <see cref="LoadRuntimeFont"/>.
+        /// </remarks>
+        public RuntimeFontProvider RuntimeFonts { get; private set; }
 
         /// <summary>
         /// Create a new instance of <see cref="FontSystem" /> base on the provided <see cref="Stride.Graphics.GraphicsDevice" />.
@@ -52,7 +56,7 @@ namespace Stride.Graphics.Font
         /// Loads a runtime-registered font by name.
         /// This bypasses the content pipeline entirely.
         /// </summary>
-        /// <param name="fontName">The registered font name</param>
+        /// <param name="fontName">The registered font name. If the font is not registered, the method returns <c>null</c>.</param>
         /// <param name="defaultSize">The default font size</param>
         /// <param name="style">The font style</param>
         /// <returns>A SpriteFont instance, or null if not registered</returns>

--- a/sources/engine/Stride.Graphics/Font/RuntimeFontProvider.cs
+++ b/sources/engine/Stride.Graphics/Font/RuntimeFontProvider.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation and Contributors (https://dotnetfoundation.org/ & https://stride3d.net)
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Stride.Graphics.Font;
+
+/// <summary>
+/// Provides runtime registration and loading of fonts from the file system.
+/// </summary>
+public class RuntimeFontProvider
+{
+    private readonly FontSystem fontSystem;
+    private readonly Dictionary<string, RuntimeFontInfo> registeredFonts = [];
+
+    internal RuntimeFontProvider(FontSystem fontSystem)
+    {
+        this.fontSystem = fontSystem;
+    }
+
+    /// <summary>
+    /// Registers a font file for runtime loading.
+    /// </summary>
+    /// <param name="fontName">The name to use when loading the font (e.g., "MyFont").</param>
+    /// <param name="filePath">The absolute or relative path to the .ttf file.</param>
+    /// <param name="style">The font style.</param>
+    public void RegisterFont(string fontName, string filePath, FontStyle style = FontStyle.Regular)
+    {
+        if (string.IsNullOrEmpty(fontName))
+            throw new ArgumentNullException(nameof(fontName));
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"Font file not found: {filePath}", filePath);
+
+        var key = GetFontKey(fontName, style);
+        registeredFonts[key] = new RuntimeFontInfo(fontName, filePath, style);
+
+        // Preload into FontManager's cache
+        fontSystem.FontManager.LoadFontFromFileSystem(fontName, filePath, style);
+    }
+
+    /// <summary>
+    /// Checks if a font is registered for runtime loading.
+    /// </summary>
+    /// <param name="fontName">The font name.</param>
+    /// <param name="style">The font style.</param>
+    /// <returns>True if registered, false otherwise.</returns>
+    public bool IsRegistered(string fontName, FontStyle style = FontStyle.Regular)
+    {
+        return registeredFonts.ContainsKey(GetFontKey(fontName, style));
+    }
+
+    private static string GetFontKey(string fontName, FontStyle style)
+    {
+        return $"{fontName}_{style}";
+    }
+
+    private record RuntimeFontInfo(string FontName, string FilePath, FontStyle Style);
+}

--- a/sources/engine/Stride.Graphics/Font/RuntimeFontProvider.cs
+++ b/sources/engine/Stride.Graphics/Font/RuntimeFontProvider.cs
@@ -10,6 +10,15 @@ namespace Stride.Graphics.Font;
 /// <summary>
 /// Provides runtime registration and loading of fonts from the file system.
 /// </summary>
+/// <remarks>
+/// <para>This provider allows loading custom TrueType fonts (.ttf) at runtime without going through
+/// the content pipeline. Fonts registered through this provider are immediately available for use
+/// with <see cref="FontSystem.LoadRuntimeFont"/>.</para>
+/// <para><strong>Memory Management:</strong> All registered fonts remain in memory for the lifetime
+/// of the application. There is no mechanism to unload individual fonts once registered. For applications
+/// with dynamic font requirements or memory constraints, consider the total memory footprint of all
+/// registered fonts.</para>
+/// </remarks>
 public class RuntimeFontProvider
 {
     private readonly FontSystem fontSystem;
@@ -23,22 +32,42 @@ public class RuntimeFontProvider
     /// <summary>
     /// Registers a font file for runtime loading.
     /// </summary>
+    /// <remarks>
+    /// <para>Once registered, fonts are loaded into memory and cached for the lifetime of the font system.
+    /// Individual fonts cannot be unregistered or unloaded - they remain in memory until the application exits
+    /// or the font system is disposed.</para>
+    /// <para>Attempting to register the same font name and style with a different file path will throw an exception.</para>
+    /// </remarks>
     /// <param name="fontName">The name to use when loading the font (e.g., "MyFont").</param>
     /// <param name="filePath">The absolute or relative path to the .ttf file.</param>
     /// <param name="style">The font style.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fontName"/> is null or empty.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the font file does not exist.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when attempting to register the same font name and style with a different file path.</exception>
     public void RegisterFont(string fontName, string filePath, FontStyle style = FontStyle.Regular)
     {
-        if (string.IsNullOrEmpty(fontName))
-            throw new ArgumentNullException(nameof(fontName));
+        ArgumentException.ThrowIfNullOrWhiteSpace(fontName);
 
         if (!File.Exists(filePath))
             throw new FileNotFoundException($"Font file not found: {filePath}", filePath);
 
-        var key = GetFontKey(fontName, style);
-        registeredFonts[key] = new RuntimeFontInfo(fontName, filePath, style);
+        var key = FontHelper.GetFontPath(fontName, style);
 
-        // Preload into FontManager's cache
+        if (registeredFonts.TryGetValue(key, out var existing))
+        {
+            if (existing.FilePath == filePath) return;
+
+            throw new InvalidOperationException(
+                $"Font '{fontName}' with style '{style}' is already registered with path '{existing.FilePath}'. " +
+                $"Cannot register a different path '{filePath}' for the same font name and style.");
+        }
+
+        if (registeredFonts.ContainsKey(key))
+            return;
+
         fontSystem.FontManager.LoadFontFromFileSystem(fontName, filePath, style);
+
+        registeredFonts[key] = new RuntimeFontInfo(fontName, filePath, style);
     }
 
     /// <summary>
@@ -49,12 +78,7 @@ public class RuntimeFontProvider
     /// <returns>True if registered, false otherwise.</returns>
     public bool IsRegistered(string fontName, FontStyle style = FontStyle.Regular)
     {
-        return registeredFonts.ContainsKey(GetFontKey(fontName, style));
-    }
-
-    private static string GetFontKey(string fontName, FontStyle style)
-    {
-        return $"{fontName}_{style}";
+        return registeredFonts.ContainsKey(FontHelper.GetFontPath(fontName, style));
     }
 
     private record RuntimeFontInfo(string FontName, string FilePath, FontStyle Style);

--- a/sources/engine/Stride.Graphics/Font/RuntimeFontProvider.cs
+++ b/sources/engine/Stride.Graphics/Font/RuntimeFontProvider.cs
@@ -62,9 +62,6 @@ public class RuntimeFontProvider
                 $"Cannot register a different path '{filePath}' for the same font name and style.");
         }
 
-        if (registeredFonts.ContainsKey(key))
-            return;
-
         fontSystem.FontManager.LoadFontFromFileSystem(fontName, filePath, style);
 
         registeredFonts[key] = new RuntimeFontInfo(fontName, filePath, style);


### PR DESCRIPTION
- Introduced LoadFontFromFileSystem() in FontManager.cs to load and cache fonts from the file system, ensuring thread safety and preventing duplicate caching.
- Added RuntimeFonts property in FontSystem.cs to expose the RuntimeFontProvider instance.
- Added LoadRuntimeFont() in FontSystem.cs to load runtime-registered fonts by name, bypassing the content pipeline.
- Introduced RuntimeFontProvider class in RuntimeFontProvider.cs to manage runtime font registration and loading.
  - Added RegisterFont() to register font files for runtime use and preload them into the FontManager cache.
  - Added IsRegistered() to check if a font is registered for runtime use.
  - Added internal caching of registered fonts using a dictionary keyed by font name and style.
- Added RuntimeFontInfo record in RuntimeFontProvider.cs to store metadata about registered fonts.

# PR Details

<!--- Provide a general summary of your changes in the Title of this PR -->
<!--- Describe your changes in detail here -->
<!--- Visit https://doc.stride3d.net/latest/en/contributors/contribution-workflow/github-pull-request-guidelines.html for more -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] **I have built and run the editor to try this change out.**
